### PR TITLE
[codex] harden API authorization and validation

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,9 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
+  {
+    ignores: [".next/**", "dist/**", "next-env.d.ts"],
+  },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
 ];
 

--- a/migrations/0002_authz_indexes_and_cascade.sql
+++ b/migrations/0002_authz_indexes_and_cascade.sql
@@ -1,0 +1,18 @@
+ALTER TABLE "messages"
+  DROP CONSTRAINT IF EXISTS "messages_chat_id_chats_id_fk";
+
+ALTER TABLE "messages"
+  ADD CONSTRAINT "messages_chat_id_chats_id_fk"
+  FOREIGN KEY ("chat_id")
+  REFERENCES "public"."chats"("id")
+  ON DELETE CASCADE
+  ON UPDATE NO ACTION;
+
+CREATE INDEX IF NOT EXISTS "chats_user_id_idx"
+  ON "chats" ("user_id");
+
+CREATE INDEX IF NOT EXISTS "chats_user_id_file_key_idx"
+  ON "chats" ("user_id", "file_key");
+
+CREATE INDEX IF NOT EXISTS "messages_chat_id_user_id_idx"
+  ON "messages" ("chat_id", "user_id");

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "build:ingestion-lambda": "esbuild src/lib/ingestion-lambda.ts --bundle --platform=node --target=node22 --format=cjs --alias:server-only=./src/lib/lambda-server-only.ts --outfile=dist/ingestion-lambda/index.cjs",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "pretty": "prettier --write \"./**/*.{js,jsx,mjs,cjs,ts,tsx,json}\""
   },
   "dependencies": {

--- a/src/app/(app)/chat/[chatId]/page.tsx
+++ b/src/app/(app)/chat/[chatId]/page.tsx
@@ -35,7 +35,6 @@ const ChatPage = async (props: Props) => {
       <ChatWorkspace
         chats={_chats}
         chatId={chatId}
-        userId={userId}
         currentChat={currentChat}
       />
     </main>

--- a/src/app/(app)/chat/[chatId]/page.tsx
+++ b/src/app/(app)/chat/[chatId]/page.tsx
@@ -32,11 +32,7 @@ const ChatPage = async (props: Props) => {
   return (
     <main className="h-screen overflow-hidden bg-[#070A12] p-3 text-white">
       <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_20%_10%,rgba(74,222,128,.18),transparent_28%),radial-gradient(circle_at_80%_0%,rgba(96,165,250,.14),transparent_30%)]" />
-      <ChatWorkspace
-        chats={_chats}
-        chatId={chatId}
-        currentChat={currentChat}
-      />
+      <ChatWorkspace chats={_chats} chatId={chatId} currentChat={currentChat} />
     </main>
   );
 };

--- a/src/app/api/ai/route.ts
+++ b/src/app/api/ai/route.ts
@@ -37,12 +37,9 @@ export async function POST(req: Request) {
 
   const fileKey = chat.fileKey;
   const context = await getContext(lastMessageContent, fileKey);
-  console.log("RAG context", {
+  console.log("RAG context retrieved", {
     chatId,
-    fileKey,
-    question: lastMessageContent,
     contextLength: context?.length ?? 0,
-    context,
   });
   const system = `You are a helpful PDF assistant.
 You will be provided with a **CONTEXT BLOCK** containing information extracted from an uploaded PDF. Your primary goal is to accurately answer user questions using *only* the information found within this **CONTEXT BLOCK**.

--- a/src/app/api/ai/route.ts
+++ b/src/app/api/ai/route.ts
@@ -2,36 +2,40 @@ import { convertToModelMessages, streamText, type UIMessage } from "ai";
 import { bedrock } from "@/lib/bedrock";
 import { env } from "@/lib/env/server";
 import { getContext } from "@/lib/context";
-import { chats, messages as _messages } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { messages as _messages } from "@/lib/db/schema";
 import { db } from "@/lib/db";
 import { NextResponse } from "next/server";
+import { getAuthenticatedUserId, getOwnedChat } from "@/lib/authz";
 
 export async function POST(req: Request) {
-  const { messages, chatId, userId } = (await req.json()) as {
+  const userId = await getAuthenticatedUserId();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { messages, chatId } = (await req.json()) as {
     messages: UIMessage[];
     chatId: string;
-    userId: string;
   };
   const lastMessage = messages[messages.length - 1];
-  const lastMessageContent = getMessageText(lastMessage);
-  const _chats = await db
-    .select()
-    .from(chats)
-    .where(eq(chats.id, chatId))
-    .execute();
+  if (!lastMessage) {
+    return NextResponse.json({ error: "Missing message" }, { status: 400 });
+  }
 
-  if (_chats.length != 1) {
+  const lastMessageContent = getMessageText(lastMessage);
+  const chat = await getOwnedChat(chatId, userId);
+
+  if (!chat) {
     return NextResponse.json({ error: "Chat not found" }, { status: 404 });
   }
-  if (_chats[0].ingestionStatus !== "ready") {
+  if (chat.ingestionStatus !== "ready") {
     return NextResponse.json(
-      { error: `PDF is ${_chats[0].ingestionStatus}` },
+      { error: `PDF is ${chat.ingestionStatus}` },
       { status: 409 },
     );
   }
 
-  const fileKey = _chats[0].fileKey;
+  const fileKey = chat.fileKey;
   const context = await getContext(lastMessageContent, fileKey);
   console.log("RAG context", {
     chatId,

--- a/src/app/api/chat/[chatId]/messages/route.ts
+++ b/src/app/api/chat/[chatId]/messages/route.ts
@@ -1,6 +1,6 @@
+import { getAuthenticatedUserId, getOwnedChat } from "@/lib/authz";
 import { db } from "@/lib/db";
-import { chats, messages } from "@/lib/db/schema";
-import { auth } from "@clerk/nextjs/server";
+import { messages } from "@/lib/db/schema";
 import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
@@ -8,11 +8,21 @@ export const GET = async (
   req: Request,
   { params }: { params: Promise<{ chatId: string }> },
 ) => {
+  const userId = await getAuthenticatedUserId();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const { chatId } = await params;
+  const chat = await getOwnedChat(chatId, userId);
+  if (!chat) {
+    return NextResponse.json({ error: "Chat not found" }, { status: 404 });
+  }
+
   const _messages = await db
     .select()
     .from(messages)
-    .where(eq(messages.chatId, chatId))
+    .where(and(eq(messages.chatId, chatId), eq(messages.userId, userId)))
     .execute();
   return NextResponse.json(_messages, { status: 200 });
 };
@@ -21,19 +31,21 @@ export const DELETE = async (
   req: Request,
   { params }: { params: Promise<{ chatId: string }> },
 ) => {
-  const { userId } = await auth();
-  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const userId = await getAuthenticatedUserId();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
   const { chatId } = await params;
-  const [chat] = await db
-    .select({ id: chats.id })
-    .from(chats)
-    .where(and(eq(chats.id, chatId), eq(chats.userId, userId)));
+  const chat = await getOwnedChat(chatId, userId);
 
   if (!chat) {
     return NextResponse.json({ error: "Chat not found" }, { status: 404 });
   }
 
-  await db.delete(messages).where(eq(messages.chatId, chatId)).execute();
+  await db
+    .delete(messages)
+    .where(and(eq(messages.chatId, chatId), eq(messages.userId, userId)))
+    .execute();
   return NextResponse.json({ ok: true }, { status: 200 });
 };

--- a/src/app/api/chat/[chatId]/route.ts
+++ b/src/app/api/chat/[chatId]/route.ts
@@ -1,30 +1,41 @@
+import { getAuthenticatedUserId, getOwnedChat } from "@/lib/authz";
 import { db } from "@/lib/db";
 import { chats, messages } from "@/lib/db/schema";
 import { deleteFromPinecone } from "@/lib/pinecone";
 import { deleteFromS3 } from "@/lib/s3";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
 export const GET = async (
   req: Request,
   { params }: { params: Promise<{ chatId: string }> },
 ) => {
-  const { chatId } = await params;
-  const _chats = await db.select().from(chats).where(eq(chats.id, chatId));
+  const userId = await getAuthenticatedUserId();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
-  if (_chats.length === 0) {
+  const { chatId } = await params;
+  const chat = await getOwnedChat(chatId, userId);
+
+  if (!chat) {
     return NextResponse.json({ error: "Chat not found" }, { status: 404 });
   }
 
-  return NextResponse.json(_chats[0], { status: 200 });
+  return NextResponse.json(chat, { status: 200 });
 };
 
 export const DELETE = async (
   req: Request,
   { params }: { params: Promise<{ chatId: string }> },
 ) => {
+  const userId = await getAuthenticatedUserId();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const { chatId } = await params;
-  const [chat] = await db.select().from(chats).where(eq(chats.id, chatId));
+  const chat = await getOwnedChat(chatId, userId);
 
   if (!chat) {
     return NextResponse.json({ error: "Chat not found" }, { status: 404 });
@@ -35,8 +46,14 @@ export const DELETE = async (
     deleteFromS3(chat.fileKey),
   ]);
 
-  await db.delete(messages).where(eq(messages.chatId, chatId)).execute();
-  await db.delete(chats).where(eq(chats.id, chatId)).execute();
+  await db
+    .delete(messages)
+    .where(and(eq(messages.chatId, chatId), eq(messages.userId, userId)))
+    .execute();
+  await db
+    .delete(chats)
+    .where(and(eq(chats.id, chatId), eq(chats.userId, userId)))
+    .execute();
 
   return NextResponse.json(chat.fileKey, { status: 200 });
 };

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -40,7 +40,10 @@ export async function POST(req: Request) {
   try {
     const parsed = createChatSchema.safeParse(await req.json());
     if (!parsed.success) {
-      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Invalid request body" },
+        { status: 400 },
+      );
     }
 
     const { file_key, file_name } = parsed.data;

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -6,6 +6,12 @@ import { checkSubscription } from "@/lib/subscriptions";
 import { auth } from "@clerk/nextjs/server";
 import { count, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
+import { z } from "zod";
+
+const createChatSchema = z.object({
+  file_key: z.string().min(1),
+  file_name: z.string().min(1),
+});
 
 export async function POST(req: Request) {
   const userId = await (await auth()).userId;
@@ -32,9 +38,15 @@ export async function POST(req: Request) {
     }
   }
   try {
-    const body = await req.json();
-    const { file_key, file_name }: { file_key: string; file_name: string } =
-      body;
+    const parsed = createChatSchema.safeParse(await req.json());
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
+    const { file_key, file_name } = parsed.data;
+    if (!file_key.startsWith(`uploads/${userId}/`)) {
+      return NextResponse.json({ error: "Invalid file key" }, { status: 400 });
+    }
 
     const chatId = await db
       .insert(chats)

--- a/src/app/api/s3/delete/route.ts
+++ b/src/app/api/s3/delete/route.ts
@@ -1,3 +1,4 @@
+import { getAuthenticatedUserId, getOwnedChatByFileKey } from "@/lib/authz";
 import { envClient } from "@/lib/env/client";
 import { DeleteObjectCommand } from "@aws-sdk/client-s3";
 import { NextResponse } from "next/server";
@@ -5,6 +6,11 @@ import { S3 } from "@/lib/s3/S3Client";
 
 export async function DELETE(request: Request) {
   try {
+    const userId = await getAuthenticatedUserId();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     const body = await request.json();
     const fileKey = body.key;
 
@@ -13,6 +19,10 @@ export async function DELETE(request: Request) {
         { error: "Missing or invalid object key" },
         { status: 400 },
       );
+    }
+    const chat = await getOwnedChatByFileKey(fileKey, userId);
+    if (!chat) {
+      return NextResponse.json({ error: "File not found" }, { status: 404 });
     }
 
     const command = new DeleteObjectCommand({

--- a/src/app/api/s3/presign/get/route.ts
+++ b/src/app/api/s3/presign/get/route.ts
@@ -1,8 +1,14 @@
+import { getAuthenticatedUserId, getOwnedChatByFileKey } from "@/lib/authz";
 import { getS3PresignedUrl } from "@/lib/s3";
 import { NextResponse } from "next/server";
 
 export async function GET(request: Request) {
   try {
+    const userId = await getAuthenticatedUserId();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     const { searchParams } = new URL(request.url);
     const fileKey = searchParams.get("file_key");
     if (!fileKey) {
@@ -10,6 +16,10 @@ export async function GET(request: Request) {
         { error: "Missing or invalid object key" },
         { status: 400 },
       );
+    }
+    const chat = await getOwnedChatByFileKey(fileKey, userId);
+    if (!chat) {
+      return NextResponse.json({ error: "File not found" }, { status: 404 });
     }
 
     const presignedUrl = await getS3PresignedUrl(fileKey);

--- a/src/app/api/s3/presign/upload/route.ts
+++ b/src/app/api/s3/presign/upload/route.ts
@@ -1,4 +1,5 @@
-import { envClient } from "@/lib/env/client";
+import { getAuthenticatedUserId } from "@/lib/authz";
+import { env } from "@/lib/env/server";
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { NextResponse } from "next/server";
 import { z } from "zod";
@@ -6,14 +7,25 @@ import { v4 as uuidv4 } from "uuid";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { S3 } from "@/lib/s3/S3Client";
 
+const MAX_UPLOAD_SIZE_BYTES = 10 * 1024 * 1024;
+const PDF_CONTENT_TYPE = "application/pdf";
+
 const fileUploadSchema = z.object({
   fileName: z.string().min(1, { message: "File name is required" }),
-  contentType: z.string().min(1, { message: "Content type is required" }),
-  size: z.number().min(1, { message: "Size is required" }),
-  isPDF: z.boolean(),
+  contentType: z.literal(PDF_CONTENT_TYPE),
+  size: z
+    .number()
+    .int()
+    .min(1, { message: "Size is required" })
+    .max(MAX_UPLOAD_SIZE_BYTES, { message: "File must be 10MB or smaller" }),
 });
 export async function POST(request: Request) {
   try {
+    const userId = await getAuthenticatedUserId();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     const body = await request.json();
     const validation = fileUploadSchema.safeParse(body);
     if (!validation.success) {
@@ -24,9 +36,10 @@ export async function POST(request: Request) {
     }
     const { fileName, contentType, size } = validation.data;
 
-    const fileKey = `uploads/${uuidv4()}-${fileName}`;
+    const safeFileName = fileName.replace(/[^a-zA-Z0-9._-]/g, "_");
+    const fileKey = `uploads/${userId}/${uuidv4()}-${safeFileName}`;
     const command = new PutObjectCommand({
-      Bucket: envClient.NEXT_PUBLIC_S3_BUCKET_NAME,
+      Bucket: env.NEXT_PUBLIC_S3_BUCKET_NAME,
       ContentType: contentType,
       ContentLength: size,
       Key: fileKey,

--- a/src/components/ChatComponent.tsx
+++ b/src/components/ChatComponent.tsx
@@ -83,7 +83,9 @@ const ChatComponent = ({ chatId, ingestionStatus }: Props) => {
     <div className="flex h-full flex-col">
       <div className="flex items-start justify-between gap-3 border-b border-white/10 p-5">
         <div>
-          <h3 className="text-xl font-semibold tracking-tight text-white">Chat</h3>
+          <h3 className="text-xl font-semibold tracking-tight text-white">
+            Chat
+          </h3>
           {currentStatus !== "ready" && (
             <p className="mt-1 text-sm text-slate-300">
               {currentStatus === "processing"

--- a/src/components/ChatComponent.tsx
+++ b/src/components/ChatComponent.tsx
@@ -11,11 +11,10 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 type Props = {
   chatId: string;
-  userId: string;
   ingestionStatus: "processing" | "ready" | "failed";
 };
 
-const ChatComponent = ({ chatId, userId, ingestionStatus }: Props) => {
+const ChatComponent = ({ chatId, ingestionStatus }: Props) => {
   const [input, setInput] = useState("");
   const queryClient = useQueryClient();
   const { data, isPending } = useQuery({
@@ -45,7 +44,7 @@ const ChatComponent = ({ chatId, userId, ingestionStatus }: Props) => {
   const { messages, sendMessage, setMessages } = useChat({
     transport: new DefaultChatTransport({
       api: "/api/ai",
-      body: { chatId, userId },
+      body: { chatId },
     }),
   });
 

--- a/src/components/ChatWorkspace.tsx
+++ b/src/components/ChatWorkspace.tsx
@@ -14,11 +14,7 @@ type Props = {
   currentChat: DrizzleChat;
 };
 
-export default function ChatWorkspace({
-  chats,
-  chatId,
-  currentChat,
-}: Props) {
+export default function ChatWorkspace({ chats, chatId, currentChat }: Props) {
   const [sidebarOpen, setSidebarOpen] = useState(true);
 
   return (

--- a/src/components/ChatWorkspace.tsx
+++ b/src/components/ChatWorkspace.tsx
@@ -11,14 +11,12 @@ import { useState } from "react";
 type Props = {
   chats: DrizzleChat[];
   chatId: string;
-  userId: string;
   currentChat: DrizzleChat;
 };
 
 export default function ChatWorkspace({
   chats,
   chatId,
-  userId,
   currentChat,
 }: Props) {
   const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -54,7 +52,6 @@ export default function ChatWorkspace({
       <section className="overflow-hidden rounded-[2rem] border border-white/10 bg-white/[.04] shadow-2xl shadow-black/40 backdrop-blur-xl">
         <ChatComponent
           chatId={chatId}
-          userId={userId}
           ingestionStatus={currentChat.ingestionStatus}
         />
       </section>

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import { auth } from "@clerk/nextjs/server";
+import { and, eq } from "drizzle-orm";
+import { db } from "./db";
+import { chats } from "./db/schema";
+
+export async function getAuthenticatedUserId() {
+  const { userId } = await auth();
+  return userId;
+}
+
+export async function getOwnedChat(chatId: string, userId: string) {
+  const [chat] = await db
+    .select()
+    .from(chats)
+    .where(and(eq(chats.id, chatId), eq(chats.userId, userId)))
+    .limit(1);
+
+  return chat;
+}
+
+export async function getOwnedChatByFileKey(fileKey: string, userId: string) {
+  const [chat] = await db
+    .select()
+    .from(chats)
+    .where(and(eq(chats.fileKey, fileKey), eq(chats.userId, userId)))
+    .limit(1);
+
+  return chat;
+}

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -3,17 +3,18 @@ import { convertToAscii } from "./utils";
 import { getEmbeddings } from "./embeddings";
 import { env } from "./env/server";
 
+const MIN_CONTEXT_MATCH_SCORE = 0.2;
+
 export async function getContext(query: string, fileKey: string) {
   const queryEmbeddings = await getEmbeddings(query);
   const matches = await getMatchesFromEmbeddings(queryEmbeddings, fileKey);
   console.log("Pinecone matches", {
     index: env.PINECONE_INDEX_NAME,
-    fileKey,
     count: matches?.length ?? 0,
     scores: matches?.map((match) => match.score),
   });
   const qualifyDocs = matches?.filter(
-    (match) => match.score && match.score > 0,
+    (match) => match.score && match.score >= MIN_CONTEXT_MATCH_SCORE,
   );
   type Metadata = {
     pageNumber: number;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -15,36 +15,44 @@ export const ingestionStatusEnum = pgEnum("ingestion_status_enum", [
   "failed",
 ]);
 
-export const chats = pgTable("chats", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  pdfName: text("pdf_name").notNull(),
-  pdfUrl: text("pdf_url").notNull(),
-  createdAt: timestamp("created_at").notNull().defaultNow(),
-  userId: varchar("user_id", { length: 256 }).notNull(),
-  fileKey: text("file_key").notNull(),
-  ingestionStatus: ingestionStatusEnum("ingestion_status")
-    .notNull()
-    .default("processing"),
-  ingestionError: text("ingestion_error"),
-}, (table) => [
-  index("chats_user_id_idx").on(table.userId),
-  index("chats_user_id_file_key_idx").on(table.userId, table.fileKey),
-]);
+export const chats = pgTable(
+  "chats",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    pdfName: text("pdf_name").notNull(),
+    pdfUrl: text("pdf_url").notNull(),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    userId: varchar("user_id", { length: 256 }).notNull(),
+    fileKey: text("file_key").notNull(),
+    ingestionStatus: ingestionStatusEnum("ingestion_status")
+      .notNull()
+      .default("processing"),
+    ingestionError: text("ingestion_error"),
+  },
+  (table) => [
+    index("chats_user_id_idx").on(table.userId),
+    index("chats_user_id_file_key_idx").on(table.userId, table.fileKey),
+  ],
+);
 
 export type DrizzleChat = typeof chats.$inferSelect;
 
-export const messages = pgTable("messages", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  chatId: uuid("chat_id")
-    .references(() => chats.id, { onDelete: "cascade" })
-    .notNull(),
-  content: text("content").notNull(),
-  createdAt: timestamp("created_at").notNull().defaultNow(),
-  userId: varchar("user_id", { length: 256 }).notNull(),
-  role: userSystemEnum("role").notNull(),
-}, (table) => [
-  index("messages_chat_id_user_id_idx").on(table.chatId, table.userId),
-]);
+export const messages = pgTable(
+  "messages",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    chatId: uuid("chat_id")
+      .references(() => chats.id, { onDelete: "cascade" })
+      .notNull(),
+    content: text("content").notNull(),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    userId: varchar("user_id", { length: 256 }).notNull(),
+    role: userSystemEnum("role").notNull(),
+  },
+  (table) => [
+    index("messages_chat_id_user_id_idx").on(table.chatId, table.userId),
+  ],
+);
 
 export const subscriptions = pgTable("user_subscriptions", {
   id: uuid("id").primaryKey().defaultRandom(),

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -5,6 +5,7 @@ import {
   timestamp,
   uuid,
   varchar,
+  index,
 } from "drizzle-orm/pg-core";
 
 export const userSystemEnum = pgEnum("user_system_enum", ["assistant", "user"]);
@@ -25,20 +26,25 @@ export const chats = pgTable("chats", {
     .notNull()
     .default("processing"),
   ingestionError: text("ingestion_error"),
-});
+}, (table) => [
+  index("chats_user_id_idx").on(table.userId),
+  index("chats_user_id_file_key_idx").on(table.userId, table.fileKey),
+]);
 
 export type DrizzleChat = typeof chats.$inferSelect;
 
 export const messages = pgTable("messages", {
   id: uuid("id").primaryKey().defaultRandom(),
   chatId: uuid("chat_id")
-    .references(() => chats.id)
+    .references(() => chats.id, { onDelete: "cascade" })
     .notNull(),
   content: text("content").notNull(),
   createdAt: timestamp("created_at").notNull().defaultNow(),
   userId: varchar("user_id", { length: 256 }).notNull(),
   role: userSystemEnum("role").notNull(),
-});
+}, (table) => [
+  index("messages_chat_id_user_id_idx").on(table.chatId, table.userId),
+]);
 
 export const subscriptions = pgTable("user_subscriptions", {
   id: uuid("id").primaryKey().defaultRandom(),


### PR DESCRIPTION
## What changed

This PR hardens the PDF chat API surface and supporting project checks.

- Adds shared server-side chat ownership helpers.
- Requires authenticated ownership checks for chat, message, AI, and S3 object endpoints.
- Stops trusting client-provided `userId` in AI chat requests.
- Validates presigned PDF uploads server-side and scopes new S3 keys by user.
- Validates chat creation file keys against the authenticated user's upload prefix.
- Removes sensitive RAG context/question/file-key logging.
- Adds a minimum vector-match threshold for retrieved context.
- Adds DB indexes and cascade behavior for ownership/chat lookups.
- Modernizes validation scripts to use `eslint .` and `pnpm typecheck`, with generated artifact ignores.

## Why

The previous API routes relied too heavily on UI/server-page checks and accepted direct IDs or file keys without consistently proving resource ownership. That allowed cross-user reads/deletes and client-spoofed identity in direct API calls.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- Scoped `prettier --check` on changed source/config files
- `pnpm build` compiled successfully, then failed at page-data collection because local required environment variables were unset: `DATABASE_URL`, `NEXT_PUBLIC_S3_BUCKET_NAME`, `AWS_REGION`, `PINECONE_ENVIRONMENT`, `PINECONE_API_KEY`.

## Notes

GitHub reported existing default-branch Dependabot alerts during push: 1 high and 3 moderate vulnerabilities.
